### PR TITLE
Minimal render rate support (forceframeupdate)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ AC_PROG_CPP
 AC_PROG_CXX
 AC_PROG_INSTALL
 AC_PROG_RANLIB
+AX_CXX_COMPILE_STDCXX(11)
 
 dnl Some needed libaries for OS2
 dnl perharps join this with the other target depended checks. move them upwards

--- a/include/render.h
+++ b/include/render.h
@@ -85,7 +85,7 @@ typedef struct {
 	bool active;
 	bool aspect;
 	bool fullFrame;
-	bool forceUpdate;
+	Bitu forceRateUpdate;
 } Render_t;
 
 extern Render_t render;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -387,6 +387,15 @@ void DOSBOX_Init(void) {
 	Pint->SetMinMax(0,10);
 	Pint->Set_help("How many frames DOSBox skips before drawing one.");
 
+	Pstring = secprop->Add_string("forceframeupdate", Property::Changeable::OnlyAtStart, "false");
+	Pstring->Set_help(
+		"Force a minimum frame drawing rate. DOS apps often don't update the screen\n"
+		"if nothing has changed. This can cause issues with overlays that hook into\n"
+		"the rendering (notably Steam overlay/Big Picture). Setting this to *true*\n"
+		"will ensure a minimal frame re-draw happens on such scenes.\n"
+		"You can set your min desired rate by setting this to a number in\n"
+		"milliseconds (100 ~ 10fps)");
+
 	Pbool = secprop->Add_bool("aspect",Property::Changeable::Always,true);
 	Pbool->Set_help("Do aspect correction, if your output method doesn't support scaling this can slow things down!.");
 

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 #include <assert.h>
 #include <math.h>
+#include <string>
 
 #include "dosbox.h"
 #include "video.h"
@@ -227,9 +228,9 @@ void RENDER_EndUpdate( bool abort ) {
 			total += render.frameskip.hadSkip[i];
 		LOG_MSG( "Skipped frame %d %d", PIC_Ticks, (total * 100) / RENDER_SKIP_CACHE );
 #endif
-		// Force output to update the screen even if nothing changed...
-		// works only with custom GLSL shaders (GFX_StartUpdate() was probably not even called)
-		if (render.forceUpdate) GFX_EndUpdate( 0 );
+		// Force output to update the screen even if nothing changed.
+		// Currently only the OpenGL output is supported.
+		if (render.forceRateUpdate) GFX_EndUpdate( 0 );
 	}
 	render.frameskip.index = (render.frameskip.index + 1) & (RENDER_SKIP_CACHE - 1);
 	render.updating=false;
@@ -565,11 +566,11 @@ static void ChangeScaler(bool pressed) {
 } */
 
 void RENDER_SetForceUpdate(bool f) {
-	render.forceUpdate = f;
+	render.forceRateUpdate = f;
 }
 
 bool RENDER_GetForceUpdate() {
-	return render.forceUpdate;
+	return render.forceRateUpdate;
 }
 
 void RENDER_Init(Section * sec) {
@@ -587,7 +588,34 @@ void RENDER_Init(Section * sec) {
 	render.aspect=section->Get_bool("aspect");
 	render.frameskip.max=section->Get_int("frameskip");
 	render.frameskip.count=0;
-	render.forceUpdate=false;
+
+	// Get the minimum refresh rate.
+	// Using std::string so we can later use the more reliable stoi() function.
+	std::string forceframeupdate = section->Get_string("forceframeupdate");
+	if (forceframeupdate == "true") {
+		// @todo calculate a  minimum based on refresh rate.
+		// Current thinking is 20% of refresh rate or 100ms,
+		// whichever is higher.
+		render.forceRateUpdate = 100;
+	} else if (forceframeupdate == "false") {
+		render.forceRateUpdate = 0;
+	} else {
+		// We should have an integer value representing number of milliseconds.
+		try {
+			render.forceRateUpdate = std::stoi(forceframeupdate);
+		} catch(const std::exception&) {
+			// @todo We should probably catch the more specific exceptions for better
+			// informing the user.
+			LOG_MSG("Invalid value for 'forceframeupdate'! Should either be: true, false or a number.");
+			render.forceRateUpdate = 0;
+		}
+	}
+	if (render.forceRateUpdate ) {
+		LOG_MSG("Minimum frame refresh set: %lu", render.forceRateUpdate );
+	}
+	section->Add_int("forcerateupdate", Property::Changeable::OnlyAtStart, render.forceRateUpdate );
+
+
 	std::string cline;
 	std::string scaler;
 	//Check for commandline paramters and parse them through the configclass so they get checked against allowed values


### PR DESCRIPTION
DOS games and DOSBox tend to only render a frame if something has
changed. As some host enviroments can perform poorly if the app does not
reliably refresh its output regularly (notably Steam overlay) this new
option ensures that DOSBox outputs a minimal amount of frames even if
nothing is changing in the app.

Currently this is only implemented in the OpenGL renderer.

The new config option is under the [render] section: forceframeupdate.
This option can have any of the following values:
* false (default): Disables the feature.
* true: Sets a default minimum frame refresh rate.
* Int: A number representing the desired minimum milliseconds DOSBox
should wait before forcing a refresh. E.g: 50

Note that the rendering system will not force a re-draw of a frame if
the app has rendered a changed frame within the desired minimum refresh.
Thus if the app is outputting 30fps and forceframeupdate is set to 100ms
(10fps) then no duplicate frame will be shown (in theory).

Due to the use of std::stoi for safer conversion of forceframeupdate to
an int the build system has been updated to build with C++11.